### PR TITLE
Fix cifar.py NameError

### DIFF
--- a/src/cifar.py
+++ b/src/cifar.py
@@ -1,4 +1,4 @@
-gedimport numpy as np
+import numpy as np
 import tensorflow as tf
 import tensorflow
 import pickle


### PR DESCRIPTION
Fix NameError: name 'gdeimport' is not defined. Extra characters accidentally added during testing.
Not merged into master branch due in accordance with submission guidelines.